### PR TITLE
Feat - SSH multiplexing allows you to reuse an existing TCP connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,31 @@ $result = Process::ssh([
     ->run('ls -al');
 ```
 
+### SSH multiplexing
+
+If you want to execute multiple commands over the same SSH connection, SSH multiplexing allows you to reuse an existing TCP connection, improving efficiency and reducing overhead.
+
+```php
+$process = Process::ssh([
+    'host' => '192.168.85.5',
+    'user' => 'ubuntu',
+    'port' => 22,
+])->useMultiplexing();
+
+$commands = [
+    'ls -al', 'whoami',
+    'pwd', 'uname -a',
+    'df -h', 'top -bn1',
+    'cat /etc/os-release', 'netstat -tuln',
+    'uptime', 'tail -n 20 /var/log/syslog',
+];
+
+foreach ($commands as $command) {
+    $process->run($command)->output();
+}
+
+```
+
 ## Testing
 
 To run the package's tests:

--- a/src/ProcessSsh.php
+++ b/src/ProcessSsh.php
@@ -40,6 +40,17 @@ class ProcessSsh extends Factory
         return $this;
     }
 
+    public function useMultiplexing(string $controlPath = '', string $controlMaster = 'auto', string $controlPersist = '10m'): self
+    {
+        if ($controlPath === '') {
+            $controlPath = '/tmp/ssh_mux_%h';
+        }
+
+        $this->config['extraOptions'][] = '-o ControlMaster='.$controlMaster.' -o ControlPath='.$controlPath.' -o ControlPersist='.$controlPersist;
+
+        return $this;
+    }
+
     /**
      * Add an extra option to the SSH configuration.
      */

--- a/tests/ProcessSshTest.php
+++ b/tests/ProcessSshTest.php
@@ -77,7 +77,7 @@ it('process useMultiplexing', function () {
     expect($process->sshConfig()['extraOptions'])->toBe([
         '-o ControlMaster=yes -o ControlPath=/tmp/ssh_mux_%h-%p -o ControlPersist=5m',
     ]);
-})->only();
+});
 
 it('exception thrown when host is not set', function () {
     Process::ssh([])->run('ls');

--- a/tests/ProcessSshTest.php
+++ b/tests/ProcessSshTest.php
@@ -56,6 +56,29 @@ it('process disableStrictHostKeyChecking', function () {
     ]);
 });
 
+it('process useMultiplexing', function () {
+    $process = Process::ssh([
+        'host' => '192.168.85.5',
+        'user' => 'ubuntu',
+        'port' => 22,
+    ])
+        ->useMultiplexing();
+
+    expect($process->sshConfig()['extraOptions'])->toBe([
+        '-o ControlMaster=auto -o ControlPath=/tmp/ssh_mux_%h -o ControlPersist=10m',
+    ]);
+
+    $process = Process::ssh([
+        'host' => '192.168.85.5',
+        'user' => 'ubuntu',
+        'port' => 22,
+    ])->useMultiplexing('/tmp/ssh_mux_%h-%p', 'yes', '5m');
+
+    expect($process->sshConfig()['extraOptions'])->toBe([
+        '-o ControlMaster=yes -o ControlPath=/tmp/ssh_mux_%h-%p -o ControlPersist=5m',
+    ]);
+})->only();
+
 it('exception thrown when host is not set', function () {
     Process::ssh([])->run('ls');
 })->throws(InvalidArgumentException::class, 'Host is required for SSH connections.');


### PR DESCRIPTION
If you want to execute multiple commands over the same SSH connection, SSH multiplexing allows you to reuse an existing TCP connection, improving efficiency and reducing overhead.